### PR TITLE
Tone down vibrancy of government colours

### DIFF
--- a/data/successors.txt
+++ b/data/successors.txt
@@ -1,15 +1,15 @@
 government Predecessor
-	color 1 1 1
+	color .7 .7 .7
 
 government Successor
 	swizzle 0
-	color 0 1 0.853
+	color 0 .8 0.653
 	language "successor"
 	"friendly hail" "successor friendly hail"
 
 government "New Houses"
 	swizzle 3
-	color 1 0 0.5
+	color .8 0 0.4
 	language "successor"
 	"friendly hail" "new houses friendly hail"
 	"hostile hail" "high houses hostile hail"
@@ -21,7 +21,7 @@ government "New Houses"
 
 government "Old Houses"
 	swizzle 4
-	color 0.375 0.316 0.99
+	color 0.375 0.316 1
 	language "successor"
 	"friendly hail" "old houses friendly hail"
 	"hostile hail" "high houses hostile hail"


### PR DESCRIPTION
Successor space on the map was looking rather bright, this is just to tone it down somewhat.

Old
![image](https://user-images.githubusercontent.com/32188044/236954487-7e329e35-250f-4d73-a216-c9cfda5a5aed.png)

New
![image](https://user-images.githubusercontent.com/32188044/236954553-4fd87cf0-34a3-46d1-8874-7801929a163d.png)
