### PR TITLE
Adjust thruster size scaling in accordance with the recent engine rebalance.

### DIFF
--- a/data/successor outfits.txt
+++ b/data/successor outfits.txt
@@ -239,7 +239,7 @@ outfit `"Niis" Inductive Engines`
 	"mass" 28
 	"outfit space" -28
 	"engine capacity" -38
-	"thrust" 9.0
+	"thrust" 11.2
 	"thrusting energy" 0.6
 	"thrusting heat" 0.8
 	"afterburner thrust" 13.5
@@ -267,7 +267,7 @@ outfit `"Aqra" Inductive Thruster`
 	"outfit space" -25
 	"engine capacity" -25
 	"energy capacity" 1200
-	"thrust" 16.0
+	"thrust" 18.0
 	"thrusting energy" 1.3
 	"thrusting heat" 1.1
 	"afterburner thrust" 24.0

--- a/data/successor outfits.txt
+++ b/data/successor outfits.txt
@@ -242,7 +242,7 @@ outfit `"Niis" Inductive Engines`
 	"thrust" 11.2
 	"thrusting energy" 0.6
 	"thrusting heat" 0.8
-	"afterburner thrust" 13.5
+	"afterburner thrust" 16.8
 	"afterburner shields" 3.0
 	"afterburner heat" 1.6
 	"afterburner effect" "successor afterburner"
@@ -270,7 +270,7 @@ outfit `"Aqra" Inductive Thruster`
 	"thrust" 18.0
 	"thrusting energy" 1.3
 	"thrusting heat" 1.1
-	"afterburner thrust" 24.0
+	"afterburner thrust" 27.0
 	"afterburner shields" 4.5
 	"afterburner heat" 2.2
 	"afterburner effect" "successor afterburner"

--- a/data/successor outfits.txt
+++ b/data/successor outfits.txt
@@ -307,7 +307,7 @@ outfit `"Aqra" Inductive Reverser`
 	"outfit space" -15
 	"weapon capacity" -15
 	"energy capacity" 1200
-	"reverse thrust" 13.2
+	"reverse thrust" 14.2
 	"reverse thrusting energy" 0.9
 	"reverse thrusting heat" 0.7
 	"reverse flare sprite" "effect/successor flare/small"


### PR DESCRIPTION
Based on https://github.com/endless-sky/endless-sky/commit/d21ee81fd2343439aefc9f1ade3b5db527defaaf (from https://github.com/endless-sky/endless-sky/pull/8842)
The "Veusa" Inductive Thruster was taken as the 'large' thruster of the set, and the same methods used as in that PR were used to work out the changes to the other engines.

Niis - +24.8%
Aqra - +12.5%
Chyyra - unchanged, as it has the same raw thrust/space as the Veusa.
Veusa - unchanged, as it is the 'large' thruster and serves as the baseline.